### PR TITLE
SC-441 - React 18 type compatibility

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -65,7 +65,7 @@ export const viewStateFromMap = (map: mapboxgl.Map) => ({
 
 export const useMap = () => useContext(MapContext)
 
-export const MapProvider: FC = ({ children }) => {
+export const MapProvider: FC<{ children?: ReactNode }> = ({ children }) => {
   const [map, setMap] = useState<mapboxgl.Map | null>(null)
   const [mapLoaded, setMapLoaded] = useState(false)
 

--- a/src/Marker.tsx
+++ b/src/Marker.tsx
@@ -11,6 +11,7 @@ export type MarkerProps = {
   closeOnClick?: boolean
   anchor?: Anchor
   color?: string
+  children?: ReactNode
 }
 
 export const Marker: FC<MarkerProps> = ({


### PR DESCRIPTION
As part of SC-441 I updated to React 18. The 'children' type is no longer included so we have to specify it ourselves.

Eventually this repo should update to React 18 as well, but I am unsure how long SC-441 will be stuck in QA, so this quick fix will be enough for now.